### PR TITLE
feat: add dragable tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@pderas/tabular",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1047,6 +1047,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
+    },
+    "@pderas/dragon-drop": {
+      "version": "1.2.0",
+      "resolved": "https://npm.pkg.github.com/download/@pderas/dragon-drop/1.2.0/f1f0ba99e59343e12e71a8b15e32ffad178aca0d6cb22e6ac67d64635685be3b",
+      "integrity": "sha512-a+6cnWVwVCDNxB+4UldWIsdDI978Dts/cSB8uj+F/dQgLHj61c7oumcx5TGCPTvEoDdkpu5b4C/LHgT6/uYZvg=="
     },
     "@pderas/eslint-config": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pderas/tabular",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A new vue table component from pderas",
   "main": "dist/tables-and-chairs.umd.min.js",
   "author": "Reed Jones <reed.jones@pderas.com>",
@@ -34,8 +34,9 @@
   "bugs": {
     "url": "https://github.com/PDERAS/tabular/issues"
   },
-  "//": "no dependencies!",
-  "dependencies": {},
+  "dependencies": {
+    "@pderas/dragon-drop": "^1.2.0"
+  },
   "devDependencies": {
     "@pderas/eslint-config": "^1.1.1",
     "@vue/babel-preset-app": "^4.2.3",

--- a/src/components/TableBody.vue
+++ b/src/components/TableBody.vue
@@ -1,5 +1,21 @@
 <template>
-<div class="tabular-body">
+<DragonDrop
+    v-if="isDraggable"
+    v-slot="{ item, index }"
+    tag="div"
+    :item-key="keySelector"
+    class="tabular-body"
+    :value="getData"
+    @input="setData">
+    <div class="tabular-row">
+        <slot
+            :index="index"
+            :row="item"
+            name="row" />
+    </div>
+</DragonDrop>
+
+<div v-else class="tabular-body">
     <div
         v-for="(item, idx) in getData"
         :key="getKey(item)"
@@ -13,10 +29,18 @@
 </template>
 
 <script>
+import { DragonDrop } from '@pderas/dragon-drop';
+
 export default {
     inject: [
-        'userSuppliedData'
+        'userSuppliedData',
+        'draggable',
+        'setData'
     ],
+
+    components: {
+        DragonDrop
+    },
 
     props: {
         keySelector: {
@@ -28,6 +52,10 @@ export default {
     computed: {
         getData() {
             return this.userSuppliedData();
+        },
+
+        isDraggable() {
+            return this.draggable();
         }
     },
 

--- a/src/components/TableContainer.vue
+++ b/src/components/TableContainer.vue
@@ -8,15 +8,22 @@
 export default {
     provide() {
         return {
-            userSuppliedData: _ => this.data
+            userSuppliedData: _ => this.data,
+            draggable: _ => !!this.$listeners['drag'],
+            setData: arr => this.$emit('drag', arr)
         };
+    },
+
+    model: {
+        prop: 'data',
+        event: 'drag'
     },
 
     props: {
         data: {
             type: Array,
             required: true
-        }
+        },
     },
 };
 </script>

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import { componentsLoader } from './utils';
 
 export default {
     install(Vue, options = {}) {
+
         // Globally register table components
         Object.entries(componentsLoader(require.context('./components', false, /\.vue$/i)))
             .forEach(([name, component]) => {


### PR DESCRIPTION
tables are now draggable by swapping `:data="myArray"` with `v-model="myArray"` it will emit a `drag` event with the array in the updated order